### PR TITLE
Add methods for reliable reads

### DIFF
--- a/lib/siberite/client.rb
+++ b/lib/siberite/client.rb
@@ -143,7 +143,23 @@ module Siberite
     end
 
     def peek(queue)
-      get queue, :peek => true
+      get queue, peek: true
+    end
+
+    def get_open(queue)
+      get queue, open: true
+    end
+
+    def get_close(queue)
+      get_from_last queue, close: true
+    end
+
+    def get_close_open(queue)
+      get_from_last queue, close: true, open: true
+    end
+
+    def get_abort(queue)
+      get_from_last queue, abort: true
     end
 
     private
@@ -173,7 +189,7 @@ module Siberite
     end
 
     def extract_queue_commands(opts)
-      commands = [:open, :close, :abort, :peek].select do |key|
+      commands = [:close, :open, :abort, :peek].select do |key|
         opts[key]
       end
 

--- a/lib/siberite/client/version.rb
+++ b/lib/siberite/client/version.rb
@@ -1,3 +1,3 @@
 module Siberite
-  VERSION = "0.8.1"
+  VERSION = "0.9.0"
 end

--- a/spec/siberite/client_spec.rb
+++ b/spec/siberite/client_spec.rb
@@ -81,6 +81,51 @@ describe Siberite::Client do
       end
     end
 
+    describe "#get_open" do
+      it "opens a reliable read" do
+        @queue = "some_random_queue_#{Time.now.to_i}_#{rand(10000)}"
+        @client.set(@queue, "item_1")
+        @client.set(@queue, "item_2")
+        expect(@client.get_open(@queue)).to eq "item_1"
+        expect{ @client.get(@queue) }.to raise_error Memcached::ClientError
+        expect(@client.get_open(@queue)).to eq "item_1"
+      end
+    end
+
+    describe "#get_close" do
+      it "closes a reliable read" do
+        @queue = "some_random_queue_#{Time.now.to_i}_#{rand(10000)}"
+        @client.set(@queue, "item_1")
+        @client.set(@queue, "item_2")
+        expect(@client.get_open(@queue)).to eq "item_1"
+        expect{ @client.get_close(@queue) }.to_not raise_error
+        expect(@client.get_open(@queue)).to eq "item_2"
+      end
+    end
+
+    describe "#get_close_open" do
+      it "closes a reliable read" do
+        @queue = "some_random_queue_#{Time.now.to_i}_#{rand(10000)}"
+        @client.set(@queue, "item_1")
+        @client.set(@queue, "item_2")
+        expect(@client.get_open(@queue)).to eq "item_1"
+        expect{ @client.get(@queue) }.to raise_error Memcached::ClientError
+        expect(@client.get_open(@queue)).to eq "item_1"
+        expect(@client.get_close_open(@queue)).to eq "item_2"
+      end
+    end
+
+    describe "#get_abort" do
+      it "aborts a reliable read" do
+        @queue = "some_random_queue_#{Time.now.to_i}_#{rand(10000)}"
+        @client.set(@queue, "item_1")
+        @client.set(@queue, "item_2")
+        expect(@client.get_open(@queue)).to eq "item_1"
+        expect{ @client.get_abort(@queue) }.to_not raise_error
+        expect(@client.get(@queue)).to eq "item_1"
+      end
+    end
+
     describe "#with_retries" do
       it "retries a specified number of times" do
         mock(@client).set(anything, anything) { raise Memcached::SystemError }.times(6)


### PR DESCRIPTION
- Add client.get_open('a_queue')
- Add client.get_close('a_queue')
- Add client.get_close_open('a_queue')
- Add client.get_abort('a_queue')
- Update README.md
- Bump version to 0.9.0
